### PR TITLE
Use tabular nums for count down for better alignment

### DIFF
--- a/app/assets/stylesheets/profile.scss
+++ b/app/assets/stylesheets/profile.scss
@@ -340,6 +340,7 @@
           line-height: 22px;
           color: $light-inputTextColor;
           display: block;
+          font-variant-numeric: tabular-nums;
         }
       }
     }


### PR DESCRIPTION
# Description
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->

**Before:**

The count down "jumps" around a little bit every second because different numbers take up slightly more or slightly less space.

![2020-10-01 20 05 33](https://user-images.githubusercontent.com/876666/94846895-2a4caf80-0422-11eb-9ad0-db45a87a3876.gif)

**After:**

`font-variant-numeric: tabular-nums` straightens out the difference, kind of like a monospace font does. The result is a bit wider, but consistent.

![2020-10-01 20 05 07](https://user-images.githubusercontent.com/876666/94846912-2fa9fa00-0422-11eb-82cd-a542ec9ec1e0.gif)

It will still jump when going from 10s to 9s because it drops a character:

<img width="755" alt="image" src="https://user-images.githubusercontent.com/876666/94847282-acd56f00-0422-11eb-85ab-0f6d69253c4e.png">

# Test process
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.
-->

- [ ] Test A
- [ ] Test B

# Requirements to merge
<!--
Ensure your pull request meets all the requirements for merging. Place an `x` in each box to indicate that your pull request meets that requirement.
-->
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
